### PR TITLE
Allow using objects as both the source and the target for the inheritance

### DIFF
--- a/heir.js
+++ b/heir.js
@@ -117,16 +117,21 @@
 		// If the parent variable is not a function then it must be an array
 		// So we have to loop over it and inherit each of them
 		// Remember to pass the current function instance!
-		if (typeof parent !== 'function') {
+		if (isArray(parent)) {
 			i = parent.length;
 			while (i--) {
 				inherit(parent[i], fn);
 			}
-		}
-		else {
-			// It is not an array, it is a plain function
-			// Merge it's prototype into this one
-			merge(fn.prototype, clone(parent.prototype));
+		} else {
+
+			// Make sure we're using prototypes if we should be
+			var realParent = isFunction(parent) ?
+				parent.prototype : parent;
+
+			var realFn = isFunction(fn) ?
+				fn.prototype : fn;
+
+			merge(realFn, clone(realParent));
 		}
 
 		// Return the current function to allow chaining
@@ -139,6 +144,8 @@
 	// Create a nice little namespace to expose
 	var ns = {
 		isObject: isObject,
+		isArray: isArray,
+		isFunction: isFunction,
 		merge: merge,
 		clone: clone,
 		inherit: inherit

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -305,6 +305,19 @@
 			expect(s.bar()).toEqual('!bar!');
 			expect(s.baz()).toEqual('!baz!');
 		});
+
+		it('works with objects as the child', function() {
+			var Base = function() {};
+			Base.prototype.foo = function() {
+				return '!foo!';
+			};
+
+			var sub = {};
+
+			heir.inherit(Base, sub);
+
+			expect(sub.foo()).toEqual('!foo!');
+		});
 	});
 
 	// Run Jasmine


### PR DESCRIPTION
It should be possible to inherit both to and from an object. This patch will allow you to use a mix of either.

``` js

var Base = {
    method: function() { return 'Blah'; }
};

var Sub = {};

heir.inherit(Base, Sub);

Sub.method();
// Blah
```

I decided not to add a prototypical method on objects for inheritance as that's considered _really_ bad as it affects the **whole** javascript runtime. 
