### PR TITLE
Add a more general purpose "merge" method.

### DIFF
--- a/heir.js
+++ b/heir.js
@@ -58,7 +58,7 @@
 		 * This function merges a source into a destination.
 		 *
 		 * @param {Object} destination The destination for the merge
-		 * @param {Object} source	  The source of the properties to merge
+		 * @param {Object} source      The source of the properties to merge
 		 */
 		merge: function merge(destination, source) {
 			var key;
@@ -76,9 +76,9 @@
 		 * We should use Object.prototype.hasOwnPropety rather than
 		 * object.hasOwnProperty as it could be overwritten. 
 		 * 
-		 * @param  {Object}		 object The object to check
+		 * @param  {Object}         object The object to check
 		 * @param  {String|Number}  key	The key to check for.
-		 * @return {Boolean}			   Does object have key as an own propety?
+		 * @return {Boolean}        Does object have key as an own propety?
 		 */
 		hasOwn: function hasOwn(object, key) {
 			return Object.prototype.hasOwnProperty.call(object, key);


### PR DESCRIPTION
If we have a "merge" method, it fully duplicates the functionality presented in https://github.com/Wolfy87/Heir/pull/4, but in a much nicer way. 

I also added `heir.hasOwn`, as a shortcut for `Object.prototype.hasOwnProperty`. The "why"s for that are explained in the method's DocBlock.
